### PR TITLE
Fix missing import (by @DAP-DarkneSS)

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -21,6 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 ---------------------------------------------------------------------- */
+#include <QButtonGroup>
 #include <QFileDialog>
 #include <QDir>
 #include <QSettings>


### PR DESCRIPTION
Compiling fails without this import. In #3, @DAP-DarkneSS reported both the issue and the fix.

Fixes #3 